### PR TITLE
Address Autocompletion Example Update

### DIFF
--- a/examples/address_autocomplete.html
+++ b/examples/address_autocomplete.html
@@ -220,7 +220,7 @@ function geocodeSuggest(request, response, options) {
 						"civic_number", "intersection", "block", "street", "locality",
 						"province"</p>
 				<p>For more information on these geocoder parameters, see the
-					<a href="https://catalogue.data.gov.bc.ca/dataset/bc-address-geocoder-web-service/resource/40d6411e-ab98-4df9-a24e-67f81c45f6fa/view/1d3c42fc-53dc-4aab-ae3b-f4d056cb00e0">REST API
+					<a href="https://openapi.apps.gov.bc.ca/?url=https://raw.githubusercontent.com/bcgov/api-specs/master/geocoder/geocoder-combined.json">REST API
 						Console</a>
       </div>
     </div>

--- a/ols-demo/index.html
+++ b/ols-demo/index.html
@@ -1181,6 +1181,8 @@
 				maxFeatures: 200,
 				styles: 7834,
 				layers: 'pub:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW',
+				width: 20,
+				height: 20,
 				transparent: true,
 				format: 'image/png'
 			});

--- a/ols-demo/index.html
+++ b/ols-demo/index.html
@@ -1181,8 +1181,6 @@
 				maxFeatures: 200,
 				styles: 7834,
 				layers: 'pub:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW',
-				width: 20,
-				height: 20,
 				transparent: true,
 				format: 'image/png'
 			});

--- a/widget/index.html
+++ b/widget/index.html
@@ -174,7 +174,7 @@
 					<p>This specifies the "placeholder" text to display in the
 						field before a user has edited it.</p>
 				<p>For more information on these geocoder parameters, see the
-					<a href="https://catalogue.data.gov.bc.ca/dataset/bc-address-geocoder-web-service/resource/40d6411e-ab98-4df9-a24e-67f81c45f6fa/view/1d3c42fc-53dc-4aab-ae3b-f4d056cb00e0">REST API
+					<a href="https://openapi.apps.gov.bc.ca/?url=https://raw.githubusercontent.com/bcgov/api-specs/master/geocoder/geocoder-combined.json">REST API
 						Console</a>
       </div>
     </div>


### PR DESCRIPTION
The API console URL for the Address Autocompletion Example page was updated to use openapi.