### PR TITLE
corrected snapDistance checkbox handling

### DIFF
--- a/ols-demo/index.html
+++ b/ols-demo/index.html
@@ -2056,10 +2056,7 @@
 				params['simplifyThreshold'] = $('#simplifyThreshold').val();
 			}
 			
-			if($('#snapDistanceChk').is(':checked')) {
-				params['snapDistance'] = "true";
-			}
-			if(!isNaN( $('#snapDistance').val()) ) {
+			if($('#snapDistanceChk').is(':checked') && !isNaN( $('#snapDistance').val()) ) {
 				params['snapDistance'] = $('#snapDistance').val();
 			}
 


### PR DESCRIPTION
The logic for handling the snapDistance checkbox didn't quite make sense. Unlike the simplifyDirections checkbox, there is no option to "enable" snapping, it is always on, so the checkbox should only be used to decide whether or not to include the snapDistance value, it doesn't get included in the request itself.